### PR TITLE
CI : Add custom release to github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+    assignees: 
+      - "pyansys-ci-bot"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -14,3 +16,5 @@ updates:
       interval: "daily"
     labels:
       - "maintenance"
+    assignees: 
+      - "pyansys-ci-bot"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -166,7 +166,16 @@ jobs:
           twine-username: __token__
           twine-token: ${{ secrets.PYPI_TOKEN }}
 
-      - name: Release to GitHub
-        uses: pyansys/actions/release-github@v4
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: "Release to GitHub"
+        uses: softprops/action-gh-release@v1
         with:
-          library-name: ${{ env.PACKAGE_NAME }}
+          files: |
+            ./**/*.whl
+            ./**/*.tar.gz
+            documentation-html 


### PR DESCRIPTION
Add custom workflow for release to github, because there is not pdf artifact. Tha pyansys/actions will look for pdf.
Add assignees to pyansys-ci-bot for dependabot , and give write access to the ci bot